### PR TITLE
update mapping of CO2 from soil or biomass stock

### DIFF
--- a/brightpath/data/export/simapro-biosphere.json
+++ b/brightpath/data/export/simapro-biosphere.json
@@ -76,7 +76,7 @@
   ],
   [
     "air",
-    "Carbon dioxide, biogenic",
+    "Carbon dioxide, land transformation",
     "Carbon dioxide, from soil or biomass stock"
   ],
   [


### PR DESCRIPTION
this change is consistent with the conversion I've observed in some datasets of simapro. It is also consistent with transformation of `Methane, from soil or biomass stock`.

This affects e.g. the results using EF3.1. `carbon dioxide, biogenic` as a characterisation factor of 0 and `carbon dioxide, land transformation` a characterisation factor of 1