### PR TITLE
Link openLCA exports to UVEK references

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,19 @@ The full Sphinx guide starts at [`docs/index.rst`](docs/index.rst).
 | ecoinvent technosphere migration | Cut-off edges 3.5→3.12; reverse is inferred and policy-controlled |
 | ecoinvent biosphere migration | Edges 3.5→3.12; reverse is inferred and policy-controlled |
 | Reference catalogs | ecoinvent 3.6–3.12 cut-off/consequential and UVEK 2025 cut-off |
-| UVEK | Valid in Brightway and SimaPro; `BAFU` accepted only as an input alias |
+| UVEK | Valid in Brightway, SimaPro, and linked openLCA JSON-LD for UVEK 2025; `BAFU` accepted only as an input alias |
 | OpenLCA Excel / ecoSpold2 | Structurally reserved, but no adapter is registered or advertised |
 
 Run `brightpath formats` to discover capabilities from the installed adapters
 and migration resources instead of relying on this static table.
+
+UVEK 2025 openLCA exports use packaged references to the existing UVEK process,
+product-flow, flow-property, unit, location, and characterized elementary-flow
+UUIDs. Background entities are referenced but not copied into the foreground
+package. The reference catalog covers every packaged UVEK technosphere identity
+and 3,954 of 4,362 ecoinvent 3.10 biosphere identities present in the inspected
+UVEK openLCA database build. A missing exact reference is an export error; it is
+never replaced with an unlinked lookalike flow.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ and 3,954 of 4,362 ecoinvent 3.10 biosphere identities present in the inspected
 UVEK openLCA database build. A missing exact reference is an export error; it is
 never replaced with an unlinked lookalike flow.
 
+Foreground processes are assigned an openLCA category as well. Explicit
+openLCA categories are preserved, while SimaPro categories and inferred
+product matches are translated through process-category observations from the
+exact target database. Unresolved UVEK datasets use its existing
+`material/Others/unspecified` category instead of appearing at the process-tree
+root.
+
 ## Installation
 
 BrightPath supports Python 3.12.

--- a/brightpath/data/export/openlca_references/ATTRIBUTION.md
+++ b/brightpath/data/export/openlca_references/ATTRIBUTION.md
@@ -1,0 +1,26 @@
+# openLCA reference-catalog provenance
+
+The JSON resource in this directory contains identity fields and openLCA UUID
+references only. It does not contain background exchange amounts, process
+descriptions, or complete UVEK or ecoinvent inventories.
+
+`uvek__2025__cutoff__ecoinvent__3.10.json` was generated with
+`scripts/generate_openlca_reference_catalog.py` from these locally installed
+sources:
+
+- the UVEK 2025 Brightway database and its source openLCA process filenames;
+- the ecoinvent 3.10 biosphere identity database used by UVEK 2025; and
+- the “UVEK 2025 Version 2” openLCA database backup dated 2026-03-09, which
+  supplied exact process, product-flow, elementary-flow, flow-property, unit,
+  and location UUIDs.
+
+The source database was distributed under the legacy BAFU label. BrightPath
+normalizes that input name and publishes it as UVEK. The resource records exact
+coverage for this database build: all 11,747 technosphere identities and 3,954
+of the 4,362 ecoinvent 3.10 biosphere identities have matching openLCA
+references. Export rejects a missing exact reference rather than creating an
+unlinked lookalike flow.
+
+The `legal_review_required` status in `RESOURCE_MANIFEST.json` is intentional.
+The manifest records provenance and integrity; it is not a license grant for
+the source databases.

--- a/brightpath/data/export/openlca_references/ATTRIBUTION.md
+++ b/brightpath/data/export/openlca_references/ATTRIBUTION.md
@@ -11,8 +11,8 @@ sources:
 - the UVEK 2025 Brightway database and its source openLCA process filenames;
 - the ecoinvent 3.10 biosphere identity database used by UVEK 2025; and
 - the “UVEK 2025 Version 2” openLCA database backup dated 2026-03-09, which
-  supplied exact process, product-flow, elementary-flow, flow-property, unit,
-  and location UUIDs.
+  supplied exact process categories plus process, product-flow,
+  elementary-flow, flow-property, unit, and location UUIDs.
 
 The source database was distributed under the legacy BAFU label. BrightPath
 normalizes that input name and publishes it as UVEK. The resource records exact

--- a/brightpath/data/export/openlca_references/RESOURCE_MANIFEST.json
+++ b/brightpath/data/export/openlca_references/RESOURCE_MANIFEST.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "generator": "scripts/generate_openlca_reference_catalog.py",
+  "resources": [
+    {
+      "file": "uvek__2025__cutoff__ecoinvent__3.10.json",
+      "sha256": "288d629b71e66d23016db4c0b522ebe53cf3b9a31c9bbc87a47ac478dee11706",
+      "size": 8642959,
+      "status": "legal_review_required",
+      "technosphere_references": 11747,
+      "biosphere_references": 3954,
+      "missing_biosphere_references": 408,
+      "profile": {
+        "technosphere": {
+          "family": "uvek",
+          "version": "2025",
+          "system_model": "cutoff"
+        },
+        "biosphere": {
+          "family": "ecoinvent",
+          "version": "3.10"
+        }
+      }
+    }
+  ]
+}

--- a/brightpath/data/export/openlca_references/RESOURCE_MANIFEST.json
+++ b/brightpath/data/export/openlca_references/RESOURCE_MANIFEST.json
@@ -4,8 +4,8 @@
   "resources": [
     {
       "file": "uvek__2025__cutoff__ecoinvent__3.10.json",
-      "sha256": "288d629b71e66d23016db4c0b522ebe53cf3b9a31c9bbc87a47ac478dee11706",
-      "size": 8642959,
+      "sha256": "8f2cead19449acc7c649f23e3634d78fd798fdac86cd607093b04493e05056f2",
+      "size": 9266925,
       "status": "legal_review_required",
       "technosphere_references": 11747,
       "biosphere_references": 3954,
@@ -20,7 +20,8 @@
           "family": "ecoinvent",
           "version": "3.10"
         }
-      }
+      },
+      "process_category_references": 11747
     }
   ]
 }

--- a/brightpath/formats/openlca_categories.py
+++ b/brightpath/formats/openlca_categories.py
@@ -1,0 +1,186 @@
+"""Process-category resolution for openLCA JSON-LD exports."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from brightpath.formats.openlca_references import OpenLCAReferenceCatalog
+from brightpath.models import BackgroundProfile
+from brightpath.profiles.simapro_categories import (
+    SimaProCategoryCatalog,
+    SimaProCategoryReference,
+    normalize_simapro_category,
+    resolve_simapro_category,
+)
+from brightpath.units import normalize_unit
+
+_REFERENCE_TAXONOMY_PROFILE = BackgroundProfile("ecoinvent", "3.9.1", "cutoff")
+_UNCATEGORIZED_FOREGROUND = "foreground/Uncategorized"
+
+
+@dataclass(frozen=True)
+class OpenLCAProcessCategoryResolution:
+    """Auditable result of resolving one openLCA process category."""
+
+    category: str
+    method: str
+    confidence: float
+    candidates: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class OpenLCAProcessCategoryCatalog:
+    """Native openLCA category observations prepared for category inference."""
+
+    inference_catalog: SimaProCategoryCatalog
+    native_by_canonical: dict[str, str]
+    fallback_category: str
+
+
+def build_openlca_process_category_catalog(
+    reference_catalog: OpenLCAReferenceCatalog | None,
+) -> OpenLCAProcessCategoryCatalog | None:
+    """Build an inference view over exact process categories in a target database."""
+
+    if reference_catalog is None:
+        return None
+
+    observations: Counter[tuple[str, str, str, str]] = Counter()
+    native_counts: dict[str, Counter[str]] = {}
+    for identity, reference in reference_catalog.technosphere.items():
+        process_name, reference_product, _location, unit = identity
+        canonical = _canonical_category(reference.category)
+        if not canonical:
+            continue
+        role = _process_role(process_name)
+        observations[(reference_product, str(normalize_unit(unit)), role, canonical)] += 1
+        native_counts.setdefault(canonical, Counter())[reference.category] += 1
+
+    references = tuple(
+        SimaProCategoryReference(
+            reference_product=reference_product,
+            unit=unit,
+            process_role=role,
+            category=category,
+            dataset_count=count,
+        )
+        for (reference_product, unit, role, category), count in sorted(observations.items())
+    )
+    native_by_canonical = {
+        canonical: sorted(counts.items(), key=lambda item: (-item[1], item[0].casefold()))[0][0]
+        for canonical, counts in native_counts.items()
+    }
+    fallback = native_by_canonical.get(_canonical_category("material/Others/unspecified"))
+    if fallback is None:
+        fallback = _UNCATEGORIZED_FOREGROUND
+    return OpenLCAProcessCategoryCatalog(
+        inference_catalog=SimaProCategoryCatalog(
+            profile=_REFERENCE_TAXONOMY_PROFILE,
+            source_version="target-openlca",
+            references=references,
+            categories=frozenset(native_by_canonical),
+            digest="",
+            source=reference_catalog.source,
+        ),
+        native_by_canonical=native_by_canonical,
+        fallback_category=fallback,
+    )
+
+
+def resolve_openlca_process_category(
+    dataset: Mapping,
+    *,
+    current_category: object = "",
+    catalog: OpenLCAProcessCategoryCatalog | None = None,
+) -> OpenLCAProcessCategoryResolution:
+    """Resolve an openLCA category without mutating *dataset*.
+
+    Explicit BrightPath and existing openLCA categories take precedence. A
+    supplied SimaPro production category is translated to the exact target
+    hierarchy when possible. Otherwise, the existing product, unit, and
+    process-role resolver operates over category observations extracted from
+    the target openLCA database. Ambiguous or unknown datasets use an existing
+    target fallback instead of being left at the process-tree root.
+    """
+
+    explicit = _category_path(dataset.get("openlca category"))
+    if explicit:
+        return OpenLCAProcessCategoryResolution(explicit, "explicit", 1.0)
+
+    existing = str(current_category or "").strip()
+    if existing:
+        return OpenLCAProcessCategoryResolution(existing, "existing", 1.0)
+
+    production = next(
+        (
+            exchange
+            for exchange in dataset.get("exchanges", ())
+            if isinstance(exchange, Mapping) and exchange.get("type") == "production"
+        ),
+        {},
+    )
+    supplied_simapro = production.get("simapro category") if isinstance(production, Mapping) else ""
+    if supplied_simapro:
+        try:
+            category = normalize_simapro_category(supplied_simapro)
+        except ValueError:
+            category = _category_path(supplied_simapro)
+        native = _native_category(category, catalog)
+        if native:
+            return OpenLCAProcessCategoryResolution(native, "simapro_category", 1.0)
+        if category and catalog is None:
+            return OpenLCAProcessCategoryResolution(category, "simapro_category", 1.0)
+
+    if catalog is None:
+        return OpenLCAProcessCategoryResolution(
+            category=_UNCATEGORIZED_FOREGROUND,
+            method="foreground_fallback",
+            confidence=0.0,
+        )
+
+    resolution = resolve_simapro_category(
+        dataset,
+        profile=_REFERENCE_TAXONOMY_PROFILE,
+        catalog=catalog.inference_catalog,
+    )
+    native = _native_category(resolution.category, catalog)
+    if native:
+        return OpenLCAProcessCategoryResolution(
+            category=native,
+            method=f"target_{resolution.method}",
+            confidence=resolution.confidence,
+            candidates=resolution.candidates,
+        )
+    return OpenLCAProcessCategoryResolution(
+        category=catalog.fallback_category,
+        method="target_fallback",
+        confidence=0.0,
+        candidates=resolution.candidates,
+    )
+
+
+def _category_path(value: object) -> str:
+    parts = [part.strip() for part in str(value or "").split("/") if part.strip()]
+    return "/".join(parts)
+
+
+def _canonical_category(value: object) -> str:
+    parts = [part.strip().casefold() for part in re.split(r"[/\\]", str(value or "")) if part.strip()]
+    return "/".join(parts)
+
+
+def _native_category(
+    category: object,
+    catalog: OpenLCAProcessCategoryCatalog | None,
+) -> str:
+    if not category or catalog is None:
+        return ""
+    return catalog.native_by_canonical.get(_canonical_category(category), "")
+
+
+def _process_role(name: str) -> str:
+    normalized = name.casefold().strip()
+    return "market" if normalized.startswith(("market for ", "market group for ")) else "transformation"

--- a/brightpath/formats/openlca_jsonld.py
+++ b/brightpath/formats/openlca_jsonld.py
@@ -19,6 +19,11 @@ from typing import Any
 
 from brightpath.core.context import BackgroundContext, BiosphereProfile, FormatProfile, InventoryContext
 from brightpath.exceptions import SerializationError
+from brightpath.formats.openlca_references import (
+    OpenLCABiosphereReference,
+    OpenLCATechnosphereReference,
+    load_openlca_reference_catalog,
+)
 from brightpath.models import BackgroundProfile, InventoryDocument, InventoryFormat, default_biosphere_profile
 
 _ROOT_MANIFEST = "olca-schema.json"
@@ -387,7 +392,7 @@ def render_openlca_jsonld_package(document: InventoryDocument) -> _RenderedPacka
     """Build all openLCA root entities in memory without writing a ZIP archive."""
 
     schema, _zipio = _olca_modules()
-    builder = _OpenLCAPackageBuilder(schema, document.metadata)
+    builder = _OpenLCAPackageBuilder(schema, document.metadata, document.context)
     return builder.build(document)
 
 
@@ -963,9 +968,10 @@ def _schema_ref(entity: Any, **overrides: Any) -> Any:
 
 
 class _OpenLCAPackageBuilder:
-    def __init__(self, schema: Any, metadata: dict[str, Any]) -> None:
+    def __init__(self, schema: Any, metadata: dict[str, Any], context: InventoryContext) -> None:
         self.schema = schema
         self.metadata = deepcopy(metadata)
+        self.reference_catalog = load_openlca_reference_catalog(context)
 
         self.actors: dict[str, Any] = {}
         self.currencies: dict[str, Any] = {}
@@ -1193,44 +1199,56 @@ class _OpenLCAPackageBuilder:
                 )
                 default_provider = local[0]
             else:
-                flow_property_ref, unit_ref = self._ensure_quantity_entities(
-                    unit_name=str(exchange.get("unit") or ""),
-                    flow_property_template=_require_mapping(
-                        exchange.get(_FLOW_PROPERTY_TEMPLATE_KEY),
-                        _FLOW_PROPERTY_TEMPLATE_KEY,
-                    ),
-                    unit_group_template=_require_mapping(
-                        exchange.get(_UNIT_GROUP_TEMPLATE_KEY),
-                        _UNIT_GROUP_TEMPLATE_KEY,
-                    ),
-                    label=f"exchange {exchange.get('name')!r}",
-                )
-                flow = self._ensure_flow(
-                    exchange=exchange,
-                    flow_type=(
-                        self.schema.FlowType.ELEMENTARY_FLOW
-                        if exchange_type == "biosphere"
-                        else self.schema.FlowType.PRODUCT_FLOW
-                    ),
-                    flow_template=_require_mapping(exchange.get(_FLOW_TEMPLATE_KEY), _FLOW_TEMPLATE_KEY),
-                    flow_property_ref=flow_property_ref,
-                    location_ref=self._ensure_location(
+                background_reference = self._background_reference(exchange_type, exchange)
+                if background_reference is not None:
+                    flow_ref, flow_property_ref, unit_ref, location_ref, default_provider = (
+                        self._linked_background_refs(background_reference)
+                    )
+                else:
+                    flow_property_ref, unit_ref = self._ensure_quantity_entities(
+                        unit_name=str(exchange.get("unit") or ""),
+                        flow_property_template=_require_mapping(
+                            exchange.get(_FLOW_PROPERTY_TEMPLATE_KEY),
+                            _FLOW_PROPERTY_TEMPLATE_KEY,
+                        ),
+                        unit_group_template=_require_mapping(
+                            exchange.get(_UNIT_GROUP_TEMPLATE_KEY),
+                            _UNIT_GROUP_TEMPLATE_KEY,
+                        ),
+                        label=f"exchange {exchange.get('name')!r}",
+                    )
+                    flow = self._ensure_flow(
+                        exchange=exchange,
+                        flow_type=(
+                            self.schema.FlowType.ELEMENTARY_FLOW
+                            if exchange_type == "biosphere"
+                            else self.schema.FlowType.PRODUCT_FLOW
+                        ),
+                        flow_template=_require_mapping(exchange.get(_FLOW_TEMPLATE_KEY), _FLOW_TEMPLATE_KEY),
+                        flow_property_ref=flow_property_ref,
+                        location_ref=self._ensure_location(
+                            str(exchange.get("location") or ""),
+                            _require_mapping(exchange.get(_LOCATION_TEMPLATE_KEY), _LOCATION_TEMPLATE_KEY),
+                        ),
+                        default_name=(
+                            str(exchange.get("name") or "")
+                            if exchange_type == "biosphere"
+                            else str(exchange.get("reference product") or exchange.get("product") or "")
+                        ),
+                        categories=tuple(exchange.get("categories") or ()),
+                    )
+                    flow_ref = _schema_ref(
+                        flow,
+                        flow_type=flow.flow_type,
+                        ref_unit=str(exchange.get("unit") or ""),
+                    )
+                    location_ref = self._ensure_location(
                         str(exchange.get("location") or ""),
                         _require_mapping(exchange.get(_LOCATION_TEMPLATE_KEY), _LOCATION_TEMPLATE_KEY),
-                    ),
-                    default_name=(
-                        str(exchange.get("name") or "")
-                        if exchange_type == "biosphere"
-                        else str(exchange.get("reference product") or exchange.get("product") or "")
-                    ),
-                    categories=tuple(exchange.get("categories") or ()),
-                )
-                flow_ref = _schema_ref(flow, flow_type=flow.flow_type, ref_unit=str(exchange.get("unit") or ""))
-                location_ref = self._ensure_location(
-                    str(exchange.get("location") or ""),
-                    _require_mapping(exchange.get(_LOCATION_TEMPLATE_KEY), _LOCATION_TEMPLATE_KEY),
-                )
-                default_provider = self._default_provider(dataset, exchange)
+                    )
+                    default_provider = (
+                        self._default_provider(dataset, exchange) if exchange_type == "technosphere" else None
+                    )
 
             entity.is_input = exchange_type == "technosphere" or (
                 exchange_type == "biosphere" and tuple(exchange.get("categories") or ())[:1] == ("natural resource",)
@@ -1302,6 +1320,76 @@ class _OpenLCAPackageBuilder:
             ref_type=self.schema.RefType.Process,
         )
         return ref
+
+    def _background_reference(
+        self,
+        exchange_type: str,
+        exchange: dict[str, Any],
+    ) -> OpenLCATechnosphereReference | OpenLCABiosphereReference | None:
+        catalog = self.reference_catalog
+        if catalog is None:
+            return None
+        if exchange_type == "technosphere":
+            identity = (
+                str(exchange.get("name") or ""),
+                str(exchange.get("reference product") or exchange.get("product") or ""),
+                str(exchange.get("location") or ""),
+                str(exchange.get("unit") or ""),
+            )
+            reference = catalog.technosphere.get(identity)
+        else:
+            identity = (
+                str(exchange.get("name") or ""),
+                tuple(str(value) for value in exchange.get("categories") or ()),
+                str(exchange.get("unit") or ""),
+            )
+            reference = catalog.biosphere.get(identity)
+        if reference is None:
+            raise SerializationError(
+                f"Exchange {exchange.get('name')!r} has no exact {exchange_type} reference in the packaged "
+                "openLCA target-database catalog. Exporting a synthetic external flow would leave the imported "
+                "process unlinked."
+            )
+        return reference
+
+    def _linked_background_refs(
+        self,
+        reference: OpenLCATechnosphereReference | OpenLCABiosphereReference,
+    ) -> tuple[Any, Any, Any, Any | None, Any | None]:
+        is_technosphere = isinstance(reference, OpenLCATechnosphereReference)
+        flow_ref = self.schema.Ref(
+            id=reference.flow_id,
+            name=reference.flow_name,
+            flow_type=(self.schema.FlowType.PRODUCT_FLOW if is_technosphere else self.schema.FlowType.ELEMENTARY_FLOW),
+            ref_unit=reference.unit_name,
+            ref_type=self.schema.RefType.Flow,
+        )
+        flow_property_ref = self.schema.Ref(
+            id=reference.flow_property_id,
+            name=reference.flow_property_name,
+            ref_type=self.schema.RefType.FlowProperty,
+        )
+        unit_ref = self.schema.Ref(
+            id=reference.unit_id,
+            name=reference.unit_name,
+            ref_type=self.schema.RefType.Unit,
+        )
+        if not is_technosphere:
+            return flow_ref, flow_property_ref, unit_ref, None, None
+
+        location_ref = self.schema.Ref(
+            id=reference.location_id,
+            name=reference.location,
+            ref_type=self.schema.RefType.Location,
+        )
+        provider_ref = self.schema.Ref(
+            id=reference.process_id,
+            name=reference.process_name,
+            location=reference.location,
+            process_type=self.schema.ProcessType.UNIT_PROCESS,
+            ref_type=self.schema.RefType.Process,
+        )
+        return flow_ref, flow_property_ref, unit_ref, location_ref, provider_ref
 
     def _store_exchange_extras(self, entity: Any, exchange: dict[str, Any]) -> None:
         extras = _exchange_extras(exchange)

--- a/brightpath/formats/openlca_jsonld.py
+++ b/brightpath/formats/openlca_jsonld.py
@@ -19,6 +19,10 @@ from typing import Any
 
 from brightpath.core.context import BackgroundContext, BiosphereProfile, FormatProfile, InventoryContext
 from brightpath.exceptions import SerializationError
+from brightpath.formats.openlca_categories import (
+    build_openlca_process_category_catalog,
+    resolve_openlca_process_category,
+)
 from brightpath.formats.openlca_references import (
     OpenLCABiosphereReference,
     OpenLCATechnosphereReference,
@@ -113,6 +117,7 @@ _DATASET_MAPPED_KEYS = frozenset(
         "unit",
         "code",
         "comment",
+        "openlca category",
         "exchanges",
         "parameters",
     }
@@ -559,6 +564,8 @@ def _process_to_legacy_dataset(
         "exchanges": [],
     }
     dataset.update(_brightpath_other_properties(raw_process))
+    if process.category:
+        dataset["openlca category"] = str(process.category)
     dataset[_PROCESS_TEMPLATE_KEY] = deepcopy(raw_process)
     if location_raw := _raw_ref_entity(process.location, raw_locations):
         dataset[_LOCATION_TEMPLATE_KEY] = location_raw
@@ -972,6 +979,7 @@ class _OpenLCAPackageBuilder:
         self.schema = schema
         self.metadata = deepcopy(metadata)
         self.reference_catalog = load_openlca_reference_catalog(context)
+        self.category_catalog = build_openlca_process_category_catalog(self.reference_catalog)
 
         self.actors: dict[str, Any] = {}
         self.currencies: dict[str, Any] = {}
@@ -1050,6 +1058,11 @@ class _OpenLCAPackageBuilder:
         )
         process.name = str(dataset.get("name") or process.name or "")
         process.description = str(dataset.get("comment") or process.description or "")
+        process.category = resolve_openlca_process_category(
+            dataset,
+            current_category=process.category,
+            catalog=self.category_catalog,
+        ).category
         process.process_type = process.process_type or self.schema.ProcessType.UNIT_PROCESS
         process.other_properties = _merge_brightpath_other_properties(
             process.other_properties, _dataset_extras(dataset)

--- a/brightpath/formats/openlca_references.py
+++ b/brightpath/formats/openlca_references.py
@@ -1,0 +1,192 @@
+"""Exact target-database references for linked openLCA JSON-LD exports."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+from brightpath import DATA_DIR
+from brightpath.core.context import InventoryContext
+
+TechnosphereIdentity = tuple[str, str, str, str]
+BiosphereIdentity = tuple[str, tuple[str, ...], str]
+
+_REFERENCE_DIRECTORY = DATA_DIR / "export" / "openlca_references"
+_PACKAGED_CATALOGS = {
+    ("uvek", "2025", "cutoff", "ecoinvent", "3.10"): "uvek__2025__cutoff__ecoinvent__3.10.json",
+}
+
+
+@dataclass(frozen=True)
+class OpenLCATechnosphereReference:
+    """Existing openLCA process, product-flow, quantity, unit, and location references."""
+
+    process_id: str
+    process_name: str
+    flow_id: str
+    flow_name: str
+    flow_property_id: str
+    flow_property_name: str
+    unit_id: str
+    unit_name: str
+    location_id: str
+    location: str
+
+
+@dataclass(frozen=True)
+class OpenLCABiosphereReference:
+    """Existing characterized openLCA elementary-flow, quantity, and unit references."""
+
+    flow_id: str
+    flow_name: str
+    flow_property_id: str
+    flow_property_name: str
+    unit_id: str
+    unit_name: str
+
+
+@dataclass(frozen=True)
+class OpenLCAReferenceCatalog:
+    """Exact reference lookup for one openLCA background database profile."""
+
+    technosphere: dict[TechnosphereIdentity, OpenLCATechnosphereReference]
+    biosphere: dict[BiosphereIdentity, OpenLCABiosphereReference]
+    source: str
+
+
+def load_openlca_reference_catalog(context: InventoryContext) -> OpenLCAReferenceCatalog | None:
+    """Load packaged exact openLCA references for *context*, when available."""
+
+    technosphere = context.background.technosphere
+    biosphere = context.background.biosphere
+    filename = _PACKAGED_CATALOGS.get(
+        (
+            technosphere.family,
+            technosphere.version,
+            technosphere.system_model,
+            biosphere.family,
+            biosphere.version,
+        )
+    )
+    return _load_catalog(_REFERENCE_DIRECTORY / filename) if filename else None
+
+
+@lru_cache(maxsize=None)
+def _load_catalog(path: Path) -> OpenLCAReferenceCatalog:
+    try:
+        raw = path.read_bytes()
+        payload = json.loads(raw.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"Could not load openLCA reference catalog {path}: {error}") from error
+    if payload.get("schema_version") != 1 or payload.get("format") != "openlca_jsonld":
+        raise ValueError(f"Unsupported openLCA reference catalog schema in {path}.")
+    manifest_resource = _manifest_resource(path)
+    if manifest_resource.get("size") != len(raw) or manifest_resource.get("sha256") != hashlib.sha256(raw).hexdigest():
+        raise ValueError(f"OpenLCA reference catalog {path} does not match its integrity manifest.")
+    if payload.get("profile") != manifest_resource.get("profile"):
+        raise ValueError(f"OpenLCA reference catalog {path} has a profile that conflicts with its manifest.")
+    coverage = payload.get("coverage")
+    if not isinstance(coverage, dict):
+        raise ValueError(f"OpenLCA reference catalog {path} has invalid coverage metadata.")
+    for field in ("technosphere_references", "biosphere_references", "missing_biosphere_references"):
+        if coverage.get(field) != manifest_resource.get(field):
+            raise ValueError(
+                f"OpenLCA reference catalog {path} has {field!r} metadata that conflicts with its manifest."
+            )
+
+    technosphere: dict[TechnosphereIdentity, OpenLCATechnosphereReference] = {}
+    for index, row in enumerate(payload.get("technosphere", [])):
+        label = f"{path} technosphere row {index}"
+        identity = (
+            _text(row, "name", label),
+            _text(row, "reference_product", label),
+            _text(row, "location", label),
+            _text(row, "unit", label),
+        )
+        if identity in technosphere:
+            raise ValueError(f"Duplicate technosphere identity in {label}: {identity!r}.")
+        technosphere[identity] = OpenLCATechnosphereReference(
+            process_id=_uuid(row, "process_id", label),
+            process_name=_text(row, "process_name", label),
+            flow_id=_uuid(row, "flow_id", label),
+            flow_name=_text(row, "flow_name", label),
+            flow_property_id=_uuid(row, "flow_property_id", label),
+            flow_property_name=_text(row, "flow_property_name", label),
+            unit_id=_uuid(row, "unit_id", label),
+            unit_name=_text(row, "unit_name", label),
+            location_id=_uuid(row, "location_id", label),
+            location=identity[2],
+        )
+
+    biosphere: dict[BiosphereIdentity, OpenLCABiosphereReference] = {}
+    for index, row in enumerate(payload.get("biosphere", [])):
+        label = f"{path} biosphere row {index}"
+        categories = row.get("categories")
+        if (
+            not isinstance(categories, list)
+            or not categories
+            or not all(isinstance(value, str) and value for value in categories)
+        ):
+            raise ValueError(f"{label} has invalid categories.")
+        identity = (
+            _text(row, "name", label),
+            tuple(categories),
+            _text(row, "unit", label),
+        )
+        if identity in biosphere:
+            raise ValueError(f"Duplicate biosphere identity in {label}: {identity!r}.")
+        biosphere[identity] = OpenLCABiosphereReference(
+            flow_id=_uuid(row, "flow_id", label),
+            flow_name=_text(row, "flow_name", label),
+            flow_property_id=_uuid(row, "flow_property_id", label),
+            flow_property_name=_text(row, "flow_property_name", label),
+            unit_id=_uuid(row, "unit_id", label),
+            unit_name=_text(row, "unit_name", label),
+        )
+
+    if not technosphere or not biosphere:
+        raise ValueError(f"OpenLCA reference catalog {path} must contain both reference axes.")
+    if manifest_resource.get("technosphere_references") != len(technosphere):
+        raise ValueError(f"OpenLCA reference catalog {path} has an invalid technosphere count.")
+    if manifest_resource.get("biosphere_references") != len(biosphere):
+        raise ValueError(f"OpenLCA reference catalog {path} has an invalid biosphere count.")
+    return OpenLCAReferenceCatalog(
+        technosphere=technosphere,
+        biosphere=biosphere,
+        source=str(payload.get("source") or ""),
+    )
+
+
+def _manifest_resource(path: Path) -> dict:
+    manifest_path = path.parent / "RESOURCE_MANIFEST.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"Could not load openLCA reference manifest {manifest_path}: {error}") from error
+    if manifest.get("schema_version") != 1 or not isinstance(manifest.get("resources"), list):
+        raise ValueError(f"Unsupported openLCA reference manifest schema in {manifest_path}.")
+    matches = [resource for resource in manifest["resources"] if resource.get("file") == path.name]
+    if len(matches) != 1:
+        raise ValueError(f"OpenLCA reference catalog {path} must have exactly one manifest entry.")
+    return matches[0]
+
+
+def _text(row: object, field: str, label: str) -> str:
+    if not isinstance(row, dict):
+        raise ValueError(f"{label} must be an object.")
+    value = row.get(field)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} has invalid {field!r}.")
+    return value
+
+
+def _uuid(row: object, field: str, label: str) -> str:
+    value = _text(row, field, label)
+    try:
+        return str(uuid.UUID(value))
+    except ValueError as error:
+        raise ValueError(f"{label} has invalid UUID field {field!r}: {value!r}.") from error

--- a/brightpath/formats/openlca_references.py
+++ b/brightpath/formats/openlca_references.py
@@ -35,6 +35,7 @@ class OpenLCATechnosphereReference:
     unit_name: str
     location_id: str
     location: str
+    category: str
 
 
 @dataclass(frozen=True)
@@ -82,7 +83,7 @@ def _load_catalog(path: Path) -> OpenLCAReferenceCatalog:
         payload = json.loads(raw.decode("utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
         raise ValueError(f"Could not load openLCA reference catalog {path}: {error}") from error
-    if payload.get("schema_version") != 1 or payload.get("format") != "openlca_jsonld":
+    if payload.get("schema_version") != 2 or payload.get("format") != "openlca_jsonld":
         raise ValueError(f"Unsupported openLCA reference catalog schema in {path}.")
     manifest_resource = _manifest_resource(path)
     if manifest_resource.get("size") != len(raw) or manifest_resource.get("sha256") != hashlib.sha256(raw).hexdigest():
@@ -92,7 +93,12 @@ def _load_catalog(path: Path) -> OpenLCAReferenceCatalog:
     coverage = payload.get("coverage")
     if not isinstance(coverage, dict):
         raise ValueError(f"OpenLCA reference catalog {path} has invalid coverage metadata.")
-    for field in ("technosphere_references", "biosphere_references", "missing_biosphere_references"):
+    for field in (
+        "technosphere_references",
+        "process_category_references",
+        "biosphere_references",
+        "missing_biosphere_references",
+    ):
         if coverage.get(field) != manifest_resource.get(field):
             raise ValueError(
                 f"OpenLCA reference catalog {path} has {field!r} metadata that conflicts with its manifest."
@@ -120,6 +126,7 @@ def _load_catalog(path: Path) -> OpenLCAReferenceCatalog:
             unit_name=_text(row, "unit_name", label),
             location_id=_uuid(row, "location_id", label),
             location=identity[2],
+            category=_text(row, "category", label),
         )
 
     biosphere: dict[BiosphereIdentity, OpenLCABiosphereReference] = {}

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -22,7 +22,8 @@ Format boundaries
 -----------------
 
 * The built-in registry supports Brightway Excel, Brightway block CSV,
-  Brightway block TSV, and SimaPro CSV as file detection/read/write adapters.
+  Brightway block TSV, openLCA JSON-LD ZIP, and SimaPro CSV as file
+  detection/read/write adapters.
 * Only Brightway Excel and SimaPro CSV have dedicated v1 facades. Brightway
   CSV/TSV use the generic pipeline.
 * CSV suffixes are ambiguous. Detection inspects content and reports absent or
@@ -44,6 +45,13 @@ Format boundaries
   admit them; built-in Brightway Excel admits only the ``bw2io`` dialect.
 * BrightPath writes exchange artifacts. It does not install databases into
   Brightway, SimaPro, or another LCA application.
+* A process-only openLCA JSON-LD package can reference entities already present
+  in a target database. For UVEK 2025 with the ecoinvent 3.10 biosphere,
+  BrightPath packages exact references for all 11,747 UVEK technosphere
+  identities and 3,954 characterized elementary-flow identities found in the
+  inspected UVEK openLCA database build. The remaining 408 packaged ecoinvent
+  3.10 biosphere identities are not present under the same UUID in that build;
+  exporting one of them fails instead of creating an uncharacterized duplicate.
 
 Migration boundaries
 --------------------
@@ -142,3 +150,8 @@ The packaged identity-catalog manifest has status ``legal_review_required``.
 It records integrity and provenance but is not a license grant. Redistribution
 approval or separately licensed/local provider data is a mandatory gate before
 a stable public release.
+
+The packaged openLCA reference catalog has the same
+``legal_review_required`` status. It contains identities and entity UUIDs, not
+background exchange amounts or complete inventories. Its integrity manifest
+and attribution live under ``data/export/openlca_references``.

--- a/docs/workflows/conversion.rst
+++ b/docs/workflows/conversion.rst
@@ -231,10 +231,29 @@ The same format-only operation works for UVEK:
 
    assert uvek_csv.value.context.background == uvek_background
 
+   uvek_openlca = pipeline.convert(uvek.value, "openlca_jsonld")
+   written = pipeline.write(
+       uvek_openlca.value,
+       "foreground-uvek.zip",
+       target_format="openlca_jsonld",
+   )
+   if not written.succeeded:
+       raise RuntimeError(written.report.to_json(indent=2))
+
 This format-only step is not an ecoinvent-to-UVEK mapping. Cross-family
 background migration remains a separate explicit operation. The only packaged
 cross-family route is the heuristic forward ecoinvent 3.6–3.12 to UVEK 2025
 route; UVEK-to-ecoinvent migration remains unavailable.
+
+The UVEK 2025 openLCA writer resolves each external exchange against a
+format-specific exact-reference catalog. Technosphere exchanges use the
+existing process and product-flow UUIDs; biosphere exchanges use elementary
+flow UUIDs already characterized in the target database. These background
+entities are references only and are not copied into the foreground ZIP. If an
+identity is valid in the software-neutral background catalog but absent from
+the inspected openLCA database build, representability preflight and writing
+fail instead of emitting a package that imports silently with a disconnected
+network or zero LCIA score.
 
 File round-trip limits
 ----------------------

--- a/docs/workflows/conversion.rst
+++ b/docs/workflows/conversion.rst
@@ -255,6 +255,18 @@ the inspected openLCA database build, representability preflight and writing
 fail instead of emitting a package that imports silently with a disconnected
 network or zero LCIA score.
 
+Foreground processes are also placed in the openLCA process tree. An explicit
+``openlca category`` is preserved first, followed by a category already present
+in an openLCA process template and a supplied production-exchange
+``simapro category``. If none is available, BrightPath reuses the SimaPro
+product, unit, and process-role matching algorithm over category observations
+from the exact target openLCA database. The selected value is therefore a
+native target path, not an assumed SimaPro hierarchy. A dataset without a
+sufficiently specific match uses the target's existing
+``material/Others/unspecified`` category rather than appearing at the
+process-tree root. In UVEK 2025, for example, ``carbon dioxide, captured``
+resolves to the native ``material/chemicals/gases\\transformation`` path.
+
 File round-trip limits
 ----------------------
 

--- a/scripts/generate_openlca_reference_catalog.py
+++ b/scripts/generate_openlca_reference_catalog.py
@@ -1,0 +1,178 @@
+"""Generate exact openLCA background-link references from Brightway metadata.
+
+The raw reference input is a JSON object with ``processes`` and ``flows``
+arrays exported from the target openLCA database. Process rows are keyed by
+``process_ref_id`` and elementary-flow rows by ``flow_ref_id``. Brightway
+provides the software-neutral identities: UVEK activities retain their source
+openLCA process UUID in ``filename``, and ecoinvent biosphere flow codes retain
+the openLCA flow UUID.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+import bw2data as bd
+
+_PROCESS_FILENAME = re.compile(r"^process_([0-9a-fA-F-]{36})\.xml$")
+
+
+def _required(row: dict, field: str, *, label: str) -> str:
+    value = str(row.get(field) or "").strip()
+    if not value:
+        raise ValueError(f"{label} is missing {field!r}.")
+    return value
+
+
+def _process_id(activity) -> str:
+    filename = str(activity.get("filename") or "").strip()
+    match = _PROCESS_FILENAME.fullmatch(filename)
+    if match is None:
+        raise ValueError(f"UVEK activity {activity.key!r} has no openLCA process UUID in filename={filename!r}.")
+    return match.group(1).lower()
+
+
+def generate_catalog(
+    *,
+    raw_references: dict,
+    technosphere_database: str,
+    biosphere_database: str,
+    technosphere_profile: dict[str, str],
+    biosphere_profile: dict[str, str],
+    source: str,
+    allow_missing_biosphere: bool = False,
+) -> dict:
+    """Join exact openLCA references to Brightway background identities."""
+
+    process_rows = {
+        _required(row, "process_ref_id", label="openLCA process row").lower(): row
+        for row in raw_references.get("processes", [])
+    }
+    flow_rows = {
+        _required(row, "flow_ref_id", label="openLCA flow row").lower(): row for row in raw_references.get("flows", [])
+    }
+
+    technosphere = []
+    for activity in bd.Database(technosphere_database):
+        process_id = _process_id(activity)
+        try:
+            row = process_rows[process_id]
+        except KeyError as error:
+            raise ValueError(f"No openLCA process reference was found for {activity.key!r} ({process_id}).") from error
+        technosphere.append(
+            {
+                "name": str(activity.get("name") or ""),
+                "reference_product": str(activity.get("reference product") or ""),
+                "location": str(activity.get("location") or ""),
+                "unit": str(activity.get("unit") or ""),
+                "process_id": process_id,
+                "process_name": _required(row, "process_name", label=f"openLCA process {process_id}"),
+                "flow_id": _required(row, "flow_ref_id", label=f"openLCA process {process_id}"),
+                "flow_name": _required(row, "flow_name", label=f"openLCA process {process_id}"),
+                "flow_property_id": _required(row, "flow_property_ref_id", label=f"openLCA process {process_id}"),
+                "flow_property_name": _required(row, "flow_property_name", label=f"openLCA process {process_id}"),
+                "unit_id": _required(row, "unit_ref_id", label=f"openLCA process {process_id}"),
+                "unit_name": _required(row, "unit", label=f"openLCA process {process_id}"),
+                "location_id": _required(row, "location_ref_id", label=f"openLCA process {process_id}"),
+            }
+        )
+
+    biosphere = []
+    missing_biosphere = []
+    for flow in bd.Database(biosphere_database):
+        flow_id = str(flow.get("code") or "").strip().lower()
+        row = flow_rows.get(flow_id)
+        if row is None:
+            missing_biosphere.append(flow.key)
+            continue
+        biosphere.append(
+            {
+                "name": str(flow.get("name") or ""),
+                "categories": [str(value) for value in flow.get("categories", ())],
+                "unit": str(flow.get("unit") or ""),
+                "flow_id": flow_id,
+                "flow_name": _required(row, "flow_name", label=f"openLCA flow {flow_id}"),
+                "flow_property_id": _required(row, "flow_property_ref_id", label=f"openLCA flow {flow_id}"),
+                "flow_property_name": _required(row, "flow_property_name", label=f"openLCA flow {flow_id}"),
+                "unit_id": _required(row, "unit_ref_id", label=f"openLCA flow {flow_id}"),
+                "unit_name": _required(row, "unit", label=f"openLCA flow {flow_id}"),
+            }
+        )
+
+    if missing_biosphere and not allow_missing_biosphere:
+        sample = ", ".join(repr(key) for key in missing_biosphere[:5])
+        raise ValueError(
+            f"The openLCA target is missing {len(missing_biosphere)} Brightway biosphere flows; "
+            f"examples: {sample}. Pass --allow-missing-biosphere to record partial exact coverage."
+        )
+
+    technosphere.sort(key=lambda row: (row["name"], row["reference_product"], row["location"], row["unit"]))
+    biosphere.sort(key=lambda row: (row["name"], row["categories"], row["unit"]))
+    return {
+        "schema_version": 1,
+        "format": "openlca_jsonld",
+        "profile": {
+            "technosphere": technosphere_profile,
+            "biosphere": biosphere_profile,
+        },
+        "source": source,
+        "coverage": {
+            "technosphere_references": len(technosphere),
+            "biosphere_references": len(biosphere),
+            "missing_biosphere_references": len(missing_biosphere),
+        },
+        "technosphere": technosphere,
+        "biosphere": biosphere,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--raw-references", required=True, type=Path)
+    parser.add_argument("--project", required=True)
+    parser.add_argument("--technosphere-database", required=True)
+    parser.add_argument("--biosphere-database", required=True)
+    parser.add_argument("--technosphere-family", required=True)
+    parser.add_argument("--technosphere-version", required=True)
+    parser.add_argument("--system-model", required=True)
+    parser.add_argument("--biosphere-family", required=True)
+    parser.add_argument("--biosphere-version", required=True)
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--allow-missing-biosphere", action="store_true")
+    parser.add_argument("--output", required=True, type=Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    bd.projects.set_current(args.project)
+    raw_references = json.loads(args.raw_references.read_text(encoding="utf-8"))
+    payload = generate_catalog(
+        raw_references=raw_references,
+        technosphere_database=args.technosphere_database,
+        biosphere_database=args.biosphere_database,
+        technosphere_profile={
+            "family": args.technosphere_family,
+            "version": args.technosphere_version,
+            "system_model": args.system_model,
+        },
+        biosphere_profile={"family": args.biosphere_family, "version": args.biosphere_version},
+        source=args.source,
+        allow_missing_biosphere=args.allow_missing_biosphere,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    print(
+        f"Wrote {args.output} with {len(payload['technosphere'])} technosphere and "
+        f"{len(payload['biosphere'])} biosphere references."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_openlca_reference_catalog.py
+++ b/scripts/generate_openlca_reference_catalog.py
@@ -77,6 +77,7 @@ def generate_catalog(
                 "unit_id": _required(row, "unit_ref_id", label=f"openLCA process {process_id}"),
                 "unit_name": _required(row, "unit", label=f"openLCA process {process_id}"),
                 "location_id": _required(row, "location_ref_id", label=f"openLCA process {process_id}"),
+                "category": _required(row, "category", label=f"openLCA process {process_id}"),
             }
         )
 
@@ -112,7 +113,7 @@ def generate_catalog(
     technosphere.sort(key=lambda row: (row["name"], row["reference_product"], row["location"], row["unit"]))
     biosphere.sort(key=lambda row: (row["name"], row["categories"], row["unit"]))
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "format": "openlca_jsonld",
         "profile": {
             "technosphere": technosphere_profile,
@@ -121,6 +122,7 @@ def generate_catalog(
         "source": source,
         "coverage": {
             "technosphere_references": len(technosphere),
+            "process_category_references": len(technosphere),
             "biosphere_references": len(biosphere),
             "missing_biosphere_references": len(missing_biosphere),
         },

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -105,6 +105,7 @@ def test_formats_json_comes_from_capability_snapshot(capsys):
         "brightway_excel",
         "brightway_csv",
         "brightway_tsv",
+        "openlca_jsonld",
         "simapro_csv",
     }
 

--- a/tests/test_openlca_jsonld.py
+++ b/tests/test_openlca_jsonld.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import zipfile
+from copy import deepcopy
 
 import pytest
 
@@ -10,6 +11,10 @@ pytest.importorskip("olca_schema")
 from brightpath.analysis import SOURCE_FORMAT_OPENLCA_JSONLD, analyze_inventory, infer_source_format
 from brightpath.core import BackgroundContext, BiosphereProfile, FormatProfile, InventoryContext, TechnosphereProfile
 from brightpath.exceptions import SerializationError
+from brightpath.formats.openlca_categories import (
+    build_openlca_process_category_catalog,
+    resolve_openlca_process_category,
+)
 from brightpath.formats.openlca_jsonld import load_openlca_jsonld, write_openlca_jsonld
 from brightpath.formats.openlca_references import load_openlca_reference_catalog
 from brightpath.models import BackgroundProfile, InventoryDocument
@@ -106,15 +111,15 @@ def _uvek_document() -> InventoryDocument:
     return InventoryDocument(
         data=[
             {
-                "name": "foreground capture",
-                "reference product": "captured carbon dioxide",
+                "name": "carbon dioxide capture",
+                "reference product": "carbon dioxide, captured",
                 "location": "RER",
                 "unit": "kilogram",
                 "exchanges": [
                     {
                         "type": "production",
-                        "name": "foreground capture",
-                        "reference product": "captured carbon dioxide",
+                        "name": "carbon dioxide capture",
+                        "reference product": "carbon dioxide, captured",
                         "location": "RER",
                         "unit": "kilogram",
                         "amount": 1.0,
@@ -151,7 +156,9 @@ def test_openlca_jsonld_round_trip_preserves_process_links_and_extensions(tmp_pa
     assert loaded.context == source.context
     assert infer_source_format(archive) == SOURCE_FORMAT_OPENLCA_JSONLD
     assert loaded.data[0]["source"] == "Source A"
+    assert loaded.data[0]["openlca category"] == "material/Test"
     assert loaded.data[0]["exchanges"][0]["simapro category"] == "Materials/Test"
+    assert loaded.data[1]["openlca category"] == "foreground/Uncategorized"
     assert loaded.data[1]["parameters"][0]["group"] == "calculation"
     assert loaded.data[1]["exchanges"][1]["type"] == "technosphere"
     assert loaded.data[1]["exchanges"][1]["name"] == "input process"
@@ -171,6 +178,7 @@ def test_uvek_openlca_export_references_existing_provider_and_characterized_flow
             "flows/349b29d1-3e58-4c66-98b9-9d1a076efd2e.json",
         }
 
+        assert process["category"] == "material/chemicals/gases\\transformation"
         assert exchanges[2]["defaultProvider"]["@id"] == "0c5cc00d-0625-3fd0-bc34-5df18f4cfd77"
         assert exchanges[2]["flow"]["@id"] == "6e636642-6710-30fa-beae-bafdebd91217"
         assert exchanges[2]["flowProperty"]["@id"] == "f6811440-ee37-11de-8a39-0800200c9a66"
@@ -180,6 +188,25 @@ def test_uvek_openlca_export_references_existing_provider_and_characterized_flow
         assert exchanges[3]["unit"]["@id"] == "20aadc24-a391-41cf-b340-3e4529f44bde"
         assert "defaultProvider" not in exchanges[3]
         assert external_flow_paths.isdisjoint(handle.namelist())
+
+
+def test_openlca_export_preserves_explicit_process_category(tmp_path):
+    source = _uvek_document()
+    data = source.data
+    data[0]["openlca category"] = "material/chemicals/gases\\transformation"
+    categorized = InventoryDocument(
+        data=data,
+        context=source.context,
+        database_name=source.database_name,
+    )
+
+    archive = write_openlca_jsonld(categorized, tmp_path / "inventory.zip")
+    with zipfile.ZipFile(archive) as handle:
+        process_name = next(name for name in handle.namelist() if name.startswith("processes/"))
+        process = json.loads(handle.read(process_name))
+
+    assert process["category"] == "material/chemicals/gases\\transformation"
+    assert "openlca category" not in source.data[0]
 
 
 def test_uvek_openlca_export_rejects_unresolved_background_instead_of_creating_lookalike(tmp_path):
@@ -215,6 +242,30 @@ def test_packaged_uvek_openlca_reference_catalog_has_exact_reported_links():
     assert catalog.biosphere[("Carbon dioxide, fossil", ("air",), "kilogram")].flow_id == (
         "349b29d1-3e58-4c66-98b9-9d1a076efd2e"
     )
+
+
+def test_uvek_process_category_inference_uses_native_target_taxonomy_without_mutation():
+    references = load_openlca_reference_catalog(_uvek_context())
+    catalog = build_openlca_process_category_catalog(references)
+    activity = _uvek_document().data[0]
+    source = deepcopy(activity)
+
+    inferred = resolve_openlca_process_category(activity, catalog=catalog)
+    assert activity == source
+    activity["exchanges"][0]["simapro category"] = "Materials/Chemicals/Gases/Transformation"
+    translated = resolve_openlca_process_category(activity, catalog=catalog)
+    activity["exchanges"][0].pop("simapro category")
+    activity["name"] = "zxqv unknown foreground"
+    activity["reference product"] = "zxqv unknown product"
+    activity["exchanges"][0]["name"] = "zxqv unknown foreground"
+    activity["exchanges"][0]["reference product"] = "zxqv unknown product"
+    fallback = resolve_openlca_process_category(activity, catalog=catalog)
+
+    assert inferred.category == "material/chemicals/gases\\transformation"
+    assert inferred.method == "target_fuzzy_hierarchy"
+    assert translated.category == "material/chemicals/gases\\transformation"
+    assert translated.method == "simapro_category"
+    assert fallback.category == "material/Others/unspecified"
 
 
 def test_openlca_jsonld_reader_rejects_unsupported_root_entities(tmp_path):

--- a/tests/test_openlca_jsonld.py
+++ b/tests/test_openlca_jsonld.py
@@ -9,7 +9,9 @@ pytest.importorskip("olca_schema")
 
 from brightpath.analysis import SOURCE_FORMAT_OPENLCA_JSONLD, analyze_inventory, infer_source_format
 from brightpath.core import BackgroundContext, BiosphereProfile, FormatProfile, InventoryContext, TechnosphereProfile
+from brightpath.exceptions import SerializationError
 from brightpath.formats.openlca_jsonld import load_openlca_jsonld, write_openlca_jsonld
+from brightpath.formats.openlca_references import load_openlca_reference_catalog
 from brightpath.models import BackgroundProfile, InventoryDocument
 
 
@@ -90,6 +92,56 @@ def _document() -> InventoryDocument:
     return InventoryDocument(data=data, context=_context(), database_name="openlca-roundtrip")
 
 
+def _uvek_context() -> InventoryContext:
+    return InventoryContext(
+        format=FormatProfile("openlca_jsonld"),
+        background=BackgroundContext(
+            technosphere=TechnosphereProfile("uvek", "2025", "cutoff"),
+            biosphere=BiosphereProfile("ecoinvent", "3.10"),
+        ),
+    )
+
+
+def _uvek_document() -> InventoryDocument:
+    return InventoryDocument(
+        data=[
+            {
+                "name": "foreground capture",
+                "reference product": "captured carbon dioxide",
+                "location": "RER",
+                "unit": "kilogram",
+                "exchanges": [
+                    {
+                        "type": "production",
+                        "name": "foreground capture",
+                        "reference product": "captured carbon dioxide",
+                        "location": "RER",
+                        "unit": "kilogram",
+                        "amount": 1.0,
+                    },
+                    {
+                        "type": "technosphere",
+                        "name": "Electricity, low voltage, at grid",
+                        "reference product": "Electricity, low voltage, at grid",
+                        "location": "RER",
+                        "unit": "kilowatt hour",
+                        "amount": 0.1,
+                    },
+                    {
+                        "type": "biosphere",
+                        "name": "Carbon dioxide, fossil",
+                        "categories": ("air",),
+                        "unit": "kilogram",
+                        "amount": 0.0676,
+                    },
+                ],
+            }
+        ],
+        context=_uvek_context(),
+        database_name="uvek-linked-foreground",
+    )
+
+
 def test_openlca_jsonld_round_trip_preserves_process_links_and_extensions(tmp_path):
     source = _document()
 
@@ -105,6 +157,64 @@ def test_openlca_jsonld_round_trip_preserves_process_links_and_extensions(tmp_pa
     assert loaded.data[1]["exchanges"][1]["name"] == "input process"
     assert loaded.data[1]["exchanges"][1]["reference product"] == "intermediate"
     assert loaded.data[1]["exchanges"][1]["location"] == "CH"
+
+
+def test_uvek_openlca_export_references_existing_provider_and_characterized_flow(tmp_path):
+    archive = write_openlca_jsonld(_uvek_document(), tmp_path / "inventory.zip")
+
+    with zipfile.ZipFile(archive) as handle:
+        process_name = next(name for name in handle.namelist() if name.startswith("processes/"))
+        process = json.loads(handle.read(process_name))
+        exchanges = {exchange["internalId"]: exchange for exchange in process["exchanges"]}
+        external_flow_paths = {
+            "flows/6e636642-6710-30fa-beae-bafdebd91217.json",
+            "flows/349b29d1-3e58-4c66-98b9-9d1a076efd2e.json",
+        }
+
+        assert exchanges[2]["defaultProvider"]["@id"] == "0c5cc00d-0625-3fd0-bc34-5df18f4cfd77"
+        assert exchanges[2]["flow"]["@id"] == "6e636642-6710-30fa-beae-bafdebd91217"
+        assert exchanges[2]["flowProperty"]["@id"] == "f6811440-ee37-11de-8a39-0800200c9a66"
+        assert exchanges[2]["unit"]["@id"] == "86ad2244-1f0e-4912-af53-7865283103e4"
+        assert exchanges[3]["flow"]["@id"] == "349b29d1-3e58-4c66-98b9-9d1a076efd2e"
+        assert exchanges[3]["flowProperty"]["@id"] == "93a60a56-a3c8-11da-a746-0800200b9a66"
+        assert exchanges[3]["unit"]["@id"] == "20aadc24-a391-41cf-b340-3e4529f44bde"
+        assert "defaultProvider" not in exchanges[3]
+        assert external_flow_paths.isdisjoint(handle.namelist())
+
+
+def test_uvek_openlca_export_rejects_unresolved_background_instead_of_creating_lookalike(tmp_path):
+    source = _uvek_document()
+    data = source.data
+    data[0]["exchanges"][1]["name"] = "Unknown UVEK supplier"
+    data[0]["exchanges"][1]["reference product"] = "Unknown product"
+    unresolved = InventoryDocument(
+        data=data,
+        context=source.context,
+        database_name=source.database_name,
+    )
+
+    with pytest.raises(SerializationError, match="no exact technosphere reference"):
+        write_openlca_jsonld(unresolved, tmp_path / "inventory.zip")
+
+
+def test_packaged_uvek_openlca_reference_catalog_has_exact_reported_links():
+    catalog = load_openlca_reference_catalog(_uvek_context())
+
+    assert catalog is not None
+    assert (
+        catalog.technosphere[
+            (
+                "Electricity, low voltage, at grid",
+                "Electricity, low voltage, at grid",
+                "RER",
+                "kilowatt hour",
+            )
+        ].process_id
+        == "0c5cc00d-0625-3fd0-bc34-5df18f4cfd77"
+    )
+    assert catalog.biosphere[("Carbon dioxide, fossil", ("air",), "kilogram")].flow_id == (
+        "349b29d1-3e58-4c66-98b9-9d1a076efd2e"
+    )
 
 
 def test_openlca_jsonld_reader_rejects_unsupported_root_entities(tmp_path):

--- a/tests/test_openlca_reference_catalog.py
+++ b/tests/test_openlca_reference_catalog.py
@@ -32,6 +32,8 @@ def test_packaged_openlca_reference_manifest_matches_resource_bytes_and_counts()
     assert resource["size"] == len(raw)
     assert resource["sha256"] == hashlib.sha256(raw).hexdigest()
     assert resource["technosphere_references"] == len(payload["technosphere"]) == 11_747
+    assert resource["process_category_references"] == payload["coverage"]["process_category_references"] == 11_747
+    assert all(row["category"] for row in payload["technosphere"])
     assert resource["biosphere_references"] == len(payload["biosphere"]) == 3_954
     assert payload["coverage"]["missing_biosphere_references"] == 408
 
@@ -73,6 +75,7 @@ def test_reference_generator_joins_brightway_identities_to_openlca_entity_refs(m
                 "flow_property_name": "Mass",
                 "unit_ref_id": "00000000-0000-4000-8000-000000000006",
                 "unit": "kg",
+                "category": "material/chemicals/gases\\transformation",
             }
         ],
         "flows": [
@@ -96,11 +99,14 @@ def test_reference_generator_joins_brightway_identities_to_openlca_entity_refs(m
         source="test",
     )
 
+    assert payload["schema_version"] == 2
     assert payload["technosphere"][0]["process_id"] == "00000000-0000-3000-8000-000000000001"
     assert payload["technosphere"][0]["flow_id"] == "00000000-0000-3000-8000-000000000004"
+    assert payload["technosphere"][0]["category"] == "material/chemicals/gases\\transformation"
     assert payload["biosphere"][0]["flow_id"] == flow["code"]
     assert payload["coverage"] == {
         "technosphere_references": 1,
+        "process_category_references": 1,
         "biosphere_references": 1,
         "missing_biosphere_references": 0,
     }

--- a/tests/test_openlca_reference_catalog.py
+++ b/tests/test_openlca_reference_catalog.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+from brightpath import DATA_DIR
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "generate_openlca_reference_catalog.py"
+SCRIPT_SPEC = importlib.util.spec_from_file_location("generate_openlca_reference_catalog", SCRIPT_PATH)
+SCRIPT_MODULE = importlib.util.module_from_spec(SCRIPT_SPEC)
+assert SCRIPT_SPEC.loader is not None
+SCRIPT_SPEC.loader.exec_module(SCRIPT_MODULE)
+
+
+class FakeNode(dict):
+    def __init__(self, database: str, code: str, **values):
+        super().__init__(code=code, **values)
+        self.key = (database, code)
+
+
+def test_packaged_openlca_reference_manifest_matches_resource_bytes_and_counts():
+    directory = DATA_DIR / "export" / "openlca_references"
+    manifest = json.loads((directory / "RESOURCE_MANIFEST.json").read_text(encoding="utf-8"))
+    resource = manifest["resources"][0]
+    path = directory / resource["file"]
+    raw = path.read_bytes()
+    payload = json.loads(raw)
+
+    assert resource["status"] == "legal_review_required"
+    assert resource["size"] == len(raw)
+    assert resource["sha256"] == hashlib.sha256(raw).hexdigest()
+    assert resource["technosphere_references"] == len(payload["technosphere"]) == 11_747
+    assert resource["biosphere_references"] == len(payload["biosphere"]) == 3_954
+    assert payload["coverage"]["missing_biosphere_references"] == 408
+
+
+def test_reference_generator_joins_brightway_identities_to_openlca_entity_refs(monkeypatch):
+    activity = FakeNode(
+        "uvek",
+        "uvek-1",
+        name="supplier",
+        **{
+            "reference product": "product",
+            "location": "CH",
+            "unit": "kilogram",
+            "filename": "process_00000000-0000-3000-8000-000000000001.xml",
+        },
+    )
+    flow = FakeNode(
+        "biosphere",
+        "00000000-0000-4000-8000-000000000002",
+        name="emission",
+        categories=("air",),
+        unit="kilogram",
+    )
+    monkeypatch.setattr(
+        SCRIPT_MODULE.bd,
+        "Database",
+        lambda name: [activity] if name == "uvek" else [flow],
+    )
+    raw_references = {
+        "processes": [
+            {
+                "process_ref_id": "00000000-0000-3000-8000-000000000001",
+                "process_name": "supplier",
+                "location_ref_id": "00000000-0000-3000-8000-000000000003",
+                "location": "CH",
+                "flow_ref_id": "00000000-0000-3000-8000-000000000004",
+                "flow_name": "product {CH}",
+                "flow_property_ref_id": "00000000-0000-4000-8000-000000000005",
+                "flow_property_name": "Mass",
+                "unit_ref_id": "00000000-0000-4000-8000-000000000006",
+                "unit": "kg",
+            }
+        ],
+        "flows": [
+            {
+                "flow_ref_id": flow["code"],
+                "flow_name": "emission",
+                "flow_property_ref_id": "00000000-0000-4000-8000-000000000005",
+                "flow_property_name": "Mass",
+                "unit_ref_id": "00000000-0000-4000-8000-000000000006",
+                "unit": "kg",
+            }
+        ],
+    }
+
+    payload = SCRIPT_MODULE.generate_catalog(
+        raw_references=raw_references,
+        technosphere_database="uvek",
+        biosphere_database="biosphere",
+        technosphere_profile={"family": "uvek", "version": "2025", "system_model": "cutoff"},
+        biosphere_profile={"family": "ecoinvent", "version": "3.10"},
+        source="test",
+    )
+
+    assert payload["technosphere"][0]["process_id"] == "00000000-0000-3000-8000-000000000001"
+    assert payload["technosphere"][0]["flow_id"] == "00000000-0000-3000-8000-000000000004"
+    assert payload["biosphere"][0]["flow_id"] == flow["code"]
+    assert payload["coverage"] == {
+        "technosphere_references": 1,
+        "biosphere_references": 1,
+        "missing_biosphere_references": 0,
+    }


### PR DESCRIPTION
## Summary

- link openLCA JSON-LD exports to attributed UVEK reference catalogs
- add UVEK category data and infer native openLCA categories
- add the reference-catalog generator, integrity manifest, tests, and user documentation

## Validation

- `pytest -q` — 398 passed, 3 skipped from a clean Git archive
- `python -m sphinx -W --keep-going -b html docs …` — succeeded