### PR TITLE
Fix cross-platform CI checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 brightpath/data/**/*.json text eol=lf
+brightpath/data/export/simapro_categories/*.csv text eol=lf

--- a/brightpath/background/execution.py
+++ b/brightpath/background/execution.py
@@ -446,9 +446,7 @@ def _apply_biosphere_step(
         target_biosphere_identities=target_biosphere_identities,
     )
     _apply_factored_biosphere_replacements(data, factored_replacements, step.direction, report)
-    _apply_unambiguous_biosphere_compartment_fallback(
-        data, target_biosphere_identities, report
-    )
+    _apply_unambiguous_biosphere_compartment_fallback(data, target_biosphere_identities, report)
     return report, losses
 
 
@@ -910,9 +908,7 @@ def _apply_unambiguous_biosphere_compartment_fallback(
             )
 
 
-def _biosphere_compartments_are_related(
-    source: tuple[str, ...], target: tuple[str, ...]
-) -> bool:
+def _biosphere_compartments_are_related(source: tuple[str, ...], target: tuple[str, ...]) -> bool:
     """Return whether two category paths differ only by parent/child depth."""
     return source == target[: len(source)] or target == source[: len(target)]
 

--- a/tests/test_background_migration_execution.py
+++ b/tests/test_background_migration_execution.py
@@ -293,9 +293,7 @@ def test_reverse_biosphere_migration_falls_back_to_unique_child_compartment():
 
     assert result.succeeded, result.report.to_dict()
     assert result.value.data[0]["exchanges"][0]["categories"] == list(target_identity[1])
-    assert "migration.biosphere_parent_compartment_fallback" in {
-        issue.code for issue in result.report.issues
-    }
+    assert "migration.biosphere_parent_compartment_fallback" in {issue.code for issue in result.report.issues}
 
 
 def test_reverse_preference_resolves_polystyrene_fae_without_ambiguity():
@@ -622,22 +620,14 @@ def test_unrepresentable_biosphere_unit_change_is_removed_with_a_warning():
 
     assert result.succeeded
     assert result.value.data[0]["exchanges"] == []
-    assert "migration.biosphere_exchange_removed_unsafe_unit" in {
-        issue.code for issue in result.report.issues
-    }
-    assert "migration.biosphere_exchange_removed_unsafe_unit" in {
-        loss.code for loss in result.report.losses
-    }
+    assert "migration.biosphere_exchange_removed_unsafe_unit" in {issue.code for issue in result.report.issues}
+    assert "migration.biosphere_exchange_removed_unsafe_unit" in {loss.code for loss in result.report.losses}
 
 
 @pytest.mark.parametrize("reverse", [False, True])
 def test_standard_cubic_meter_and_sm3_biosphere_units_use_a_factor_of_one(reverse):
     resource = load_biosphere_resources()[("3.8", "3.9")]
-    rule = next(
-        rule
-        for rule in resource["replace"]
-        if rule["source"]["name"] == "Gas, natural, in ground"
-    )
+    rule = next(rule for rule in resource["replace"] if rule["source"]["name"] == "Gas, natural, in ground")
     source = background("3.9", "3.9") if reverse else background("3.8", "3.8")
     target = background("3.8", "3.8") if reverse else background("3.9", "3.9")
     source_specification = rule["target"] if reverse else rule["source"]

--- a/tests/test_simapro_inventory.py
+++ b/tests/test_simapro_inventory.py
@@ -423,7 +423,7 @@ def test_write_csv_rejects_wrong_suffix_and_normalizes_non_latin1_text(tmp_path)
     with path.open(newline="", encoding="latin-1") as handle:
         cells = [cell for row in csv.reader(handle, delimiter=";") for cell in row]
     comment = next(cell for cell in cells if "unsupported snowman" in cell)
-    assert f"25 \N{DEGREE SIGN}C-50 \N{DEGREE SIGN}C" in comment
+    assert "25 \N{DEGREE SIGN}C-50 \N{DEGREE SIGN}C" in comment
     assert "CO2 reuse" in comment
     assert 'smart quotes "ok"' in comment
     assert "unsupported snowman: ?" in comment


### PR DESCRIPTION
## Summary

- apply the repository's Black formatting to the two files rejected by the quality job
- remove one placeholder-free f-string exposed by the now-running Ruff step
- force LF checkouts for the integrity-manifested SimaPro category CSV so Git on Windows does not change its hash and size

## Root cause

The quality job stopped at Black, hiding a Ruff failure in a later step. Separately, `.gitattributes` forced LF only for JSON resources. Windows therefore checked out the manifested category CSV with CRLF bytes, causing five integrity failures and one downstream missing-category assertion.

## Validation

- `black --check brightpath tests docs/conf.py`
- `python -m isort --check-only brightpath tests docs/conf.py`
- `python -m ruff check brightpath tests docs/conf.py`
- `python -m bandit -r brightpath`
- `python -m sphinx -W --keep-going -b html docs docs/_build/html`
- `pytest -q --cov=brightpath` — 398 passed, 3 skipped
- `python -m build`
- autocrlf-enabled staged checkout: `pytest -q tests/test_simapro_categories.py` — 8 passed